### PR TITLE
Integer division bug in limit_size

### DIFF
--- a/pointillism/utils.py
+++ b/pointillism/utils.py
@@ -9,7 +9,7 @@ def limit_size(img, max_x, max_y=0):
     if max_y == 0:
         max_y = max_x
 
-    ratio = min(1.0, max_x / img.shape[1], max_y / img.shape[0])
+    ratio = min(1.0, float(max_x) / img.shape[1], float(max_y) / img.shape[0])
 
     if ratio != 1.0:
         shape = (int(img.shape[1] * ratio), int(img.shape[0] * ratio))


### PR DESCRIPTION
Prevent (0, 0) dimensions caused by integer division, found when calling palette scaling